### PR TITLE
Fix gpkg multiple layer install

### DIFF
--- a/apps/postgres/tasks.py
+++ b/apps/postgres/tasks.py
@@ -4,9 +4,22 @@ import zipfile
 from pathlib import Path
 
 
-def _cleanup(file_path: str) -> None:
+def _cleanup(file_path: str, delete_source: bool = False) -> None:
+    """Remove per-call scratch state, and the uploaded source once it's done.
+
+    A multi-layer file (e.g. a GeoPackage with several layers) is imported
+    via one request per layer, all sharing the same uploaded file_path.
+    The zip-extraction scratch dir is regenerated on every call so it's
+    always safe to remove. The source file itself is only removed when
+    delete_source is True, i.e. this is the last (or only) import request
+    for this upload -- removing it earlier would break later layers.
+    """
     try:
-        shutil.rmtree(Path(file_path).parent, ignore_errors=True)
+        parent = Path(file_path).parent
+        if delete_source:
+            shutil.rmtree(parent, ignore_errors=True)
+        else:
+            shutil.rmtree(parent / "extracted", ignore_errors=True)
     except Exception:
         pass
 
@@ -22,7 +35,7 @@ def _resolve_source(file_path: str) -> str:
     return str(extract_dir)
 
 
-def run_vector_import(cmd: list, file_path: str) -> dict:
+def run_vector_import(cmd: list, file_path: str, delete_source: bool = False) -> dict:
     try:
         source = _resolve_source(file_path)
         # Replace the file_path entry in cmd with the resolved source
@@ -40,7 +53,7 @@ def run_vector_import(cmd: list, file_path: str) -> dict:
     except Exception as e:
         return {"status": "failed", "error": str(e)}
     finally:
-        _cleanup(file_path)
+        _cleanup(file_path, delete_source)
 
 
 def run_raster_import(raster_cmd: list, conn_params: dict, file_path: str) -> dict:
@@ -73,4 +86,6 @@ def run_raster_import(raster_cmd: list, conn_params: dict, file_path: str) -> di
     except Exception as e:
         return {"status": "failed", "error": str(e)}
     finally:
-        _cleanup(file_path)
+        # A raster import is always a single request for its file, so the
+        # source can be removed unconditionally once this call is done.
+        _cleanup(file_path, delete_source=True)

--- a/apps/postgres/views.py
+++ b/apps/postgres/views.py
@@ -390,6 +390,7 @@ class PGImportView(APIView):
         source_layer = request.data.get("sourceLayer")
         srid = request.data.get("srid")
         overwrite = request.data.get("overwrite", False)
+        cleanup_source = bool(request.data.get("cleanupSource", False))
 
         if not service_name or not file_path:
             return Response(
@@ -422,7 +423,7 @@ class PGImportView(APIView):
         if srid:
             cmd.extend(["-t_srs", f"EPSG:{srid}"])
 
-        result = run_vector_import(cmd, file_path)
+        result = run_vector_import(cmd, file_path, delete_source=cleanup_source)
         if result.get("status") == "completed":
             return Response({"status": "completed"}, status=status.HTTP_200_OK)
         return Response(

--- a/tests/integration/test_postgres_workflows.py
+++ b/tests/integration/test_postgres_workflows.py
@@ -3,9 +3,11 @@
 Tests complex interactions with PostgreSQL services using mocks.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -307,6 +309,133 @@ class TestPostgresImportWorkflow:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "Service not found" in response.json()["error"]
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestPostgresImportCleanup:
+    """Tests that /api/pg/import only deletes the uploaded source file once
+    the caller signals it's no longer needed via cleanupSource.
+
+    Regression coverage for a bug where a multi-layer file (e.g. a
+    GeoPackage) was imported via one request per layer, all sharing the
+    same uploaded file path, but the source was deleted after the very
+    first layer -- breaking every subsequent layer's import.
+    """
+
+    @pytest.fixture
+    def authenticated_client(self, api_client: APIClient) -> APIClient:
+        """PGImportView requires IsAuthenticated; force_authenticate skips
+        the real auth backend so no DB-backed user is needed.
+        """
+        api_client.force_authenticate(user=get_user_model()())
+        return api_client
+
+    @pytest.fixture
+    def mock_pg_import_client(self):
+        """Mock get_pg_client() as used by PGImportView."""
+        with patch("apps.postgres.views.get_pg_client") as mock_get_client:
+            mock_service = MagicMock()
+            mock_service.host = "localhost"
+            mock_service.port = 5432
+            mock_service.dbname = "testdb"
+            mock_service.user = "testuser"
+            mock_service.password = "testpass"
+            mock_client = MagicMock()
+            mock_client.service = mock_service
+            mock_get_client.return_value = mock_client
+            yield mock_get_client
+
+    @pytest.fixture
+    def uploaded_gpkg(self, tmp_path: Path) -> Path:
+        upload_dir = tmp_path / "session-abc"
+        upload_dir.mkdir()
+        file_path = upload_dir / "combined.gpkg"
+        file_path.write_bytes(b"fake gpkg content")
+        return file_path
+
+    def test_import_without_cleanup_flag_keeps_file(
+        self,
+        authenticated_client: APIClient,
+        mock_pg_import_client: MagicMock,
+        uploaded_gpkg: Path,
+    ) -> None:
+        """Default behaviour (no cleanupSource) must not delete the source,
+        since another layer of the same upload may still need it.
+        """
+        with patch("apps.postgres.tasks.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = authenticated_client.post(
+                "/api/pg/import",
+                {
+                    "serviceName": "test_service",
+                    "filePath": str(uploaded_gpkg),
+                    "sourceLayer": "aoi",
+                    "tableName": "aoi",
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert uploaded_gpkg.exists()
+
+    def test_import_with_cleanup_flag_removes_file(
+        self,
+        authenticated_client: APIClient,
+        mock_pg_import_client: MagicMock,
+        uploaded_gpkg: Path,
+    ) -> None:
+        """cleanupSource=True (the last layer) must remove the whole
+        upload dir, including the source file.
+        """
+        with patch("apps.postgres.tasks.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            response = authenticated_client.post(
+                "/api/pg/import",
+                {
+                    "serviceName": "test_service",
+                    "filePath": str(uploaded_gpkg),
+                    "sourceLayer": "camps",
+                    "tableName": "camps",
+                    "cleanupSource": True,
+                },
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not uploaded_gpkg.parent.exists()
+
+    def test_multi_layer_import_sequence(
+        self,
+        authenticated_client: APIClient,
+        mock_pg_import_client: MagicMock,
+        uploaded_gpkg: Path,
+    ) -> None:
+        """Mirrors PGUploadDialog's per-layer loop for a 3-layer GeoPackage."""
+        layers = ["aoi", "boundary_lines", "camps"]
+        with patch("apps.postgres.tasks.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            for i, layer in enumerate(layers):
+                response = authenticated_client.post(
+                    "/api/pg/import",
+                    {
+                        "serviceName": "test_service",
+                        "filePath": str(uploaded_gpkg),
+                        "sourceLayer": layer,
+                        "tableName": layer,
+                        "cleanupSource": i == len(layers) - 1,
+                    },
+                    format="json",
+                )
+                assert response.status_code == status.HTTP_200_OK, (
+                    f"layer {layer} failed: {response.json()}"
+                )
+                if i < len(layers) - 1:
+                    assert uploaded_gpkg.exists(), (
+                        f"source must survive after layer {layer}"
+                    )
+
+        assert not uploaded_gpkg.parent.exists()
 
 
 @pytest.mark.integration

--- a/tests/unit/test_postgres_tasks.py
+++ b/tests/unit/test_postgres_tasks.py
@@ -1,0 +1,162 @@
+"""Unit tests for apps.postgres.tasks - upload cleanup after PG imports.
+
+Covers the fix for a bug where importing a multi-layer file (e.g. a
+GeoPackage with several layers) deleted the shared uploaded source file
+after the first layer's import, breaking every subsequent layer with a
+"File not found" error.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.postgres.tasks import _cleanup, run_raster_import, run_vector_import
+
+
+@pytest.fixture
+def uploaded_file(tmp_path: Path) -> Path:
+    """An uploaded file in its own session dir, plus a stale 'extracted'
+    scratch dir left over from a previous zip-shapefile extraction.
+    """
+    upload_dir = tmp_path / "uploads" / "session-123"
+    upload_dir.mkdir(parents=True)
+    file_path = upload_dir / "data.gpkg"
+    file_path.write_bytes(b"fake gpkg content")
+    extracted_dir = upload_dir / "extracted"
+    extracted_dir.mkdir()
+    (extracted_dir / "data.shp").write_bytes(b"fake shp content")
+    return file_path
+
+
+class TestCleanup:
+    """Tests for the shared _cleanup() helper."""
+
+    def test_keeps_source_by_default(self, uploaded_file: Path) -> None:
+        _cleanup(str(uploaded_file))
+
+        assert uploaded_file.exists()
+        assert not (uploaded_file.parent / "extracted").exists()
+
+    def test_deletes_source_when_requested(self, uploaded_file: Path) -> None:
+        _cleanup(str(uploaded_file), delete_source=True)
+
+        assert not uploaded_file.parent.exists()
+
+    def test_missing_extracted_dir_is_not_an_error(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "data.geojson"
+        file_path.write_bytes(b"{}")
+
+        _cleanup(str(file_path))  # no "extracted" dir was ever created
+
+        assert file_path.exists()
+
+
+class TestRunVectorImport:
+    """Tests for run_vector_import(), the entry point PGImportView calls."""
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_success_keeps_source_by_default(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = run_vector_import(["ogr2ogr", str(uploaded_file)], str(uploaded_file))
+
+        assert result == {"status": "completed"}
+        assert uploaded_file.exists()
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_success_deletes_source_when_flagged(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = run_vector_import(
+            ["ogr2ogr", str(uploaded_file)], str(uploaded_file), delete_source=True
+        )
+
+        assert result == {"status": "completed"}
+        assert not uploaded_file.parent.exists()
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_failure_still_cleans_up_when_flagged(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="ogr2ogr exploded")
+
+        result = run_vector_import(
+            ["ogr2ogr", str(uploaded_file)], str(uploaded_file), delete_source=True
+        )
+
+        assert result["status"] == "failed"
+        assert not uploaded_file.parent.exists()
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_failure_without_flag_keeps_source(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="ogr2ogr exploded")
+
+        result = run_vector_import(["ogr2ogr", str(uploaded_file)], str(uploaded_file))
+
+        assert result["status"] == "failed"
+        assert uploaded_file.exists()
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_multi_layer_sequence_keeps_source_until_last_layer(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        """Mirrors PGUploadDialog's per-layer loop for a 3-layer GeoPackage:
+        one request per layer, all sharing the same uploaded file, with
+        delete_source only true on the last one.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        cmd = ["ogr2ogr", str(uploaded_file)]
+
+        run_vector_import(cmd, str(uploaded_file), delete_source=False)  # layer 1: aoi
+        assert uploaded_file.exists(), "source must survive the first layer's import"
+
+        run_vector_import(cmd, str(uploaded_file), delete_source=False)  # layer 2: boundary_lines
+        assert uploaded_file.exists(), "source must survive the second layer's import"
+
+        run_vector_import(cmd, str(uploaded_file), delete_source=True)  # layer 3: camps (last)
+        assert not uploaded_file.parent.exists(), "source must be removed after the last layer"
+
+        assert mock_run.call_count == 3
+
+
+class TestRunRasterImport:
+    """Tests for run_raster_import(), always a single call per uploaded file."""
+
+    @patch("psycopg2.connect")
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_success_deletes_source(
+        self, mock_run: MagicMock, mock_connect: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="dummy sql", stderr="")
+        mock_connect.return_value = MagicMock()
+
+        result = run_raster_import(
+            ["raster2pgsql", str(uploaded_file)],
+            {"host": "localhost", "port": 5432, "user": "u", "password": "p", "dbname": "d"},
+            str(uploaded_file),
+        )
+
+        assert result == {"status": "completed"}
+        assert not uploaded_file.parent.exists()
+
+    @patch("apps.postgres.tasks.subprocess.run")
+    def test_raster2pgsql_failure_still_deletes_source(
+        self, mock_run: MagicMock, uploaded_file: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="raster2pgsql exploded")
+
+        result = run_raster_import(
+            ["raster2pgsql", str(uploaded_file)],
+            {"host": "localhost", "port": 5432, "user": "u", "password": "p", "dbname": "d"},
+            str(uploaded_file),
+        )
+
+        assert result["status"] == "failed"
+        assert not uploaded_file.parent.exists()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -699,6 +699,8 @@ export interface ImportRequest {
   srid?: number
   overwrite?: boolean
   sourceLayer?: string
+  /** True on the last layer of a multi-layer import so the backend removes the uploaded source file. */
+  cleanupSource?: boolean
 }
 
 export interface RasterImportRequest {

--- a/web/src/components/dialogs/PGUploadDialog.tsx
+++ b/web/src/components/dialogs/PGUploadDialog.tsx
@@ -347,7 +347,9 @@ export default function PGUploadDialog() {
         results.push({ label: selectedFile?.name ?? 'Raster import', status: 'failed', error: (err as Error).message })
       }
     } else {
-      for (const layer of selectedLayers.filter((l) => l.selected)) {
+      const layersToImport = selectedLayers.filter((l) => l.selected)
+      for (let i = 0; i < layersToImport.length; i++) {
+        const layer = layersToImport[i]
         try {
           await api.startVectorImport({
             filePath: assembledPath,
@@ -357,6 +359,7 @@ export default function PGUploadDialog() {
             sourceLayer: layer.name,
             overwrite,
             srid: targetSRID,
+            cleanupSource: i === layersToImport.length - 1,
           })
           results.push({ label: layer.name, status: 'completed' })
         } catch (err) {


### PR DESCRIPTION
This is PR for https://github.com/kartoza/GeoHosting/issues/939

**Cause:** The PG Import feature imports a multi-layer file (e.g. a GeoPackage) via one HTTP request per layer, but all requests share the same uploaded source file path. After the first layer's import, a finally block called shutil.rmtree() on the file's parent directory, deleting the shared source file entirely. Every subsequent layer's import then failed with "File not found" because the file it depended on was already gone.

**Solution:** Cleanup now only deletes the transient zip-extraction scratch folder after each individual import call, never the shared source file. A new cleanupSource flag is sent by the frontend only on the last selected layer's request, telling the backend it's now safe to delete the whole upload directory (including the original file). This preserves the original guarantee that uploaded files don't linger, while fixing multi-layer imports.

<img width="1920" height="1033" alt="Screenshot_20260730_165914" src="https://github.com/user-attachments/assets/0510ce01-47fc-41df-9340-0cd1afe2585b" />
<img width="644" height="246" alt="Screenshot_20260730_164312" src="https://github.com/user-attachments/assets/a500da46-dfe3-4499-9b37-8677db1a4920" />
<img width="591" height="760" alt="Screenshot_20260730_164034" src="https://github.com/user-attachments/assets/cf9fa1dc-d12f-4bd5-a34a-3f08ceff7ae8" />
